### PR TITLE
Fix infinite recursive loop when zipping thousand files

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "jszip": "^2.4.0"
+    "jszip": "^2.4.0",
+    "async": "^1.5.2"
   }
 }


### PR DESCRIPTION
When there are too many files that are waiting to be read, there
are too many recursive loop for each files, and then it takes
so many CPU resources that other files cannot be readed (or very slowly).
So zipping directories containing thousand files may take several minutes
(or probably may never end).

Instead of doing a recursive loop to "wait" after an other file reading,
just let's use an async queue

Closes #6
