### PR TITLE
Added ability for an inner folder name of a zip to be specified. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ zipdir('/path/to/be/zipped', { filter: (path, stat) => !/\.zip$/.test(path) }, f
 zipdir('/path/to/be/zipped', { each: path => console.log(p, "added!"), function (err, buffer) {
 
 });
+
+// Use a `innerFolderName` option which allows you to add an inner folder with a given name. 
+zipdir('/path/to/be/zipped', { innerFolderName: 'someFolderNameAsString'), function (err, buffer) {
+
+});
   
 ```
 

--- a/index.js
+++ b/index.js
@@ -53,7 +53,12 @@ function zipBuffer (rootDir, options, callback) {
   // Resolve the path so we can remove trailing slash if provided
   rootDir = path.resolve(rootDir);
 
-  folders[rootDir] = zip;
+  //Add option to change inner folder name
+  if(options.innerFolderName && typeof options.innerFolderName === 'string'){
+    folders[rootDir] = zip.folder(options.innerFolderName);
+  }else{
+    folders[rootDir] = zip;
+  }
 
   dive(rootDir, function (err) {
     if (err) return callback(err);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "zip-dir",
   "version": "2.0.0",
   "description": "Zips up directories into buffers or saves zipped files to disk",
-  "main": "index.js",
+  "main": "./test/zip-dir.test.js",
   "scripts": {
     "test": "./node_modules/.bin/mocha --reporter spec --ui bdd"
   },


### PR DESCRIPTION
Allows you to define the name of  the inner folder of the zip generated. A relevant issue can be found [HERE](https://github.com/jsantell/node-zip-dir/issues/16). 